### PR TITLE
Develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tango",
-    version="0.5.1",
+    version="0.5.2",
     author="John Sundh",
     author_email="john.sundh@scilifelab.se",
     description="A package to assign taxonomy to metagenomic contigs",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tango",
-    version="0.4.0",
+    version="0.4.1",
     author="John Sundh",
     author_email="john.sundh@scilifelab.se",
     description="A package to assign taxonomy to metagenomic contigs",

--- a/tango/assign.py
+++ b/tango/assign.py
@@ -781,7 +781,6 @@ def parse_hits(diamond_results, outfile, taxidout=False, blobout=False, top=10, 
         taxids = ids
     # Create lineage dataframe
     lineage_df, name_dict = make_lineage_df(taxids, taxdir, sqlitedb, reportranks, cpus)
-    sys.stderr.write("Size of lineage_dict: {}\n".format(sys.getsizeof(lineage_df)))
     # Set up multiprocessing pool
     items = stage_queries(res, lineage_df, input_format, rank_thresholds, top, mode, vote_threshold, assignranks,
                           reportranks, taxidmap)


### PR DESCRIPTION
With this PR the lineage dataframe only contains taxonomic ids during assigning which drastically reduces the size of the object and speeds up runtime. Only after all queries have been processed are taxonomic ids translated to names.